### PR TITLE
Improve PHP 8.1 support

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.3', '7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        php: ['7.3', '7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
         stability: ['prefer-lowest', 'prefer-stable']
 
     steps:
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-          
+
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 build
 composer.lock
 docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.3
   - 7.4
   - 8.0
+  - 8.1
 
 script:
   - composer run test

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,10 @@
         "php": "^7.4 || ^8.0"
     },
     "require-dev": {
-        "larapack/dd": "^1.1",
         "phpstan/phpstan": "^1.2.0",
         "phpunit/phpunit": "^9.5.16",
-        "php-coveralls/php-coveralls": "^2.4",
-        "squizlabs/php_codesniffer": "^3.6"
+        "php-coveralls/php-coveralls": "^2.5",
+        "symfony/var-dumper": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
         "larapack/dd": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     },
     "require-dev": {
         "larapack/dd": "^1.1",
-        "phpstan/phpstan": "^1.0.0",
-        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan": "^1.2.0",
+        "phpunit/phpunit": "^9.5.16",
         "php-coveralls/php-coveralls": "^2.4",
         "squizlabs/php_codesniffer": "^3.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,10 @@
     },
     "require-dev": {
         "larapack/dd": "^1.1",
-        "phpstan/phpstan": "^0.12.99",
+        "phpstan/phpstan": "^1.0.0",
         "phpunit/phpunit": "^9.5",
-        "php-coveralls/php-coveralls": "^2.4"
+        "php-coveralls/php-coveralls": "^2.4",
+        "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,11 @@
 parameters:
     level: max
+    checkMissingIterableValueType: false
     paths:
         - src
         - tests
+    ignoreErrors:
+        -
+            message: "#^Parameter \\#1 $data of method Navindex\\SimpleConfig\\Config::unserialize\\(\\) expects string, string|null given\\.$#"
+            count: 1
+            path: tests/ConfigTest.php

--- a/src/Config.php
+++ b/src/Config.php
@@ -242,7 +242,11 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
      */
     public function split(string $key): self
     {
-        return new self($this->get($key));
+        $value = $this->get($key);
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+        return new self($value);
     }
 
     /**
@@ -297,7 +301,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
     }
 
     /**
-     * @return \Traversable <mixed, int>
+     * @return \Traversable <mixed, mixed>
      */
     public function getIterator(): Traversable
     {
@@ -314,8 +318,8 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
         return serialize($this->config);
     }
 
-    /*
-     * @return array<string, mixed>
+    /**
+     * @return array<array-key, mixed>
      */
     public function __serialize(): array
     {
@@ -325,7 +329,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
     /**
      * Sets the configuration from a stored representation.
      *
-     * @param  mixed $data
+     * @param  string $data
      * @return void
      */
     public function unserialize($data): void
@@ -335,7 +339,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
     }
 
     /**
-     * @param  array<string, mixed> $data
+     * @param  array<string, bool|int|string> $data
      *
      * @return void
      */

--- a/src/Config.php
+++ b/src/Config.php
@@ -314,9 +314,9 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
         return serialize($this->config);
     }
 
-    public function __serialize(): ?string
+    public function __serialize(): array
     {
-        return $this->serialize();
+        return $this->config;
     }
 
     /**
@@ -331,15 +331,9 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
         $this->config = is_array($config) ? $config : [];
     }
 
-    /**
-     * Sets the configuration from a stored representation.
-     *
-     * @param  mixed $data
-     * @return void
-     */
-    public function __unserialize($data): void
+    public function __unserialize(array $data): void
     {
-        $this->unserialize($data);
+        $this->config = $data;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -339,7 +339,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
     }
 
     /**
-     * @return \Traversable <mixed, mixed>
+     * @return Traversable <string, mixed>
      */
     public function getIterator(): Traversable
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -105,7 +105,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
 
         foreach (explode('.', $key) as $k) {
             if (!is_array($config)) {
-                throw new RuntimeException("Config does not have key of `". $key . "` set.");
+                throw new RuntimeException('Config does not have key of `' . $key . '` set.');
             }
             if (!isset($config[$k])) {
                 return $default;
@@ -177,7 +177,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
 
         foreach (explode('.', $key) as $k) {
             if (!is_array($config)) {
-                throw new RuntimeException("Config does not have key of `". $key . "` set.");
+                throw new RuntimeException('Config does not have key of `' . $key . '` set.');
             }
             if (!isset($config[$k])) {
                 return $this;
@@ -202,8 +202,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
      * Merges another config into this one.
      *
      * @param  null|Config|array<string, mixed> $config Configuration array or class
-     * @param  null|int            $method Merging method
-     *
+     * @param  null|int                         $method Merging method
      * @return self
      */
     public function merge($config, ?int $method = null): self
@@ -236,7 +235,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
      *
      * @param  null|array<string, mixed>|mixed $base
      * @param  null|array<string, mixed>|mixed $replacement
-     * @param  int        $method
+     * @param  int                             $method
      * @return null|array<string, mixed>|mixed
      */
     protected function replace($base, $replacement, int $method)
@@ -245,10 +244,11 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
             if (!is_array($base) || !static::isAssoc($base)) {
                 return static::wrap($base);
             }
+
             return $base;
         }
 
-        if (!is_array($base) || !static::isAssoc($base) || !is_array($replacement)  || !static::isAssoc($replacement)) {
+        if (!is_array($base) || !static::isAssoc($base) || !is_array($replacement) || !static::isAssoc($replacement)) {
             if (self::MERGE_APPEND === $method) {
                 return array_unique(array_merge(static::wrap($base), static::wrap($replacement)));
             }
@@ -274,8 +274,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
     /**
      * Splits a sub-array of configuration options into a new config.
      *
-     * @param  string                        $key Dot notation key
-     *
+     * @param  string $key Dot notation key
      * @return Config
      */
     public function split(string $key): self
@@ -284,6 +283,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
         if (!is_array($value)) {
             $value = [$value];
         }
+
         return new self($value);
     }
 
@@ -319,7 +319,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
 
     /**
      * @param  string $offset
-     * @param  mixed $value
+     * @param  mixed  $value
      * @return void
      */
     #[\ReturnTypeWillChange]
@@ -378,7 +378,6 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
 
     /**
      * @param  array<string, bool|int|string> $data
-     *
      * @return void
      */
     public function __unserialize(array $data): void

--- a/src/Config.php
+++ b/src/Config.php
@@ -19,10 +19,10 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
 {
     // Replace the original value (default)
     const MERGE_REPLACE = 1;
-    
+
     // Keep the original value
     const MERGE_KEEP = 2;
-    
+
     // Append the new value and convert to array if necessary
     const MERGE_APPEND = 3;
 
@@ -259,6 +259,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
      * @param  mixed $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return $this->has((string) $offset);
@@ -268,6 +269,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
      * @param  mixed $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
@@ -278,6 +280,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
      * @param  mixed $value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         $this->set((string) $offset, $value);
@@ -287,6 +290,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
      * @param  mixed $offset
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         $this->unset((string) $offset);
@@ -310,6 +314,11 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
         return serialize($this->config);
     }
 
+    public function __serialize(): ?string
+    {
+        return $this->serialize();
+    }
+
     /**
      * Sets the configuration from a stored representation.
      *
@@ -320,6 +329,11 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
     {
         $config = unserialize($data, ['allowed_classes' => false]);
         $this->config = is_array($config) ? $config : [];
+    }
+
+    public function __unserialize($data): void
+    {
+        $this->unserialize($data);
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,8 +13,8 @@ use Traversable;
 /**
  * Config class.
  *
- * @implements IteratorAggregate<int>
- * @implements ArrayAccess<string, mixed>
+ * @implements IteratorAggregate<string|int>
+ * @implements ArrayAccess<string|int, mixed>
  */
 class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
 {
@@ -30,14 +30,14 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
     /**
      * Configuration settings.
      *
-     * @var array<string, mixed>
+     * @var array<string|int, mixed>
      */
     protected $config = [];
 
     /**
      * Constructor.
      *
-     * @param null|array<string, mixed> $config Configuration array
+     * @param null|array<string|int, mixed> $config Configuration array
      */
     public function __construct(?array $config = null)
     {
@@ -152,7 +152,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
 
         foreach (explode('.', $key) as $k) {
             /**
-             * @var array $config<string, mixed>
+             * @var array $config<string|int, mixed>
              */
             $config = &$config[$k];
         }
@@ -339,7 +339,7 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
     }
 
     /**
-     * @return Traversable <string, mixed>
+     * @return Traversable <string|int, mixed>
      */
     public function getIterator(): Traversable
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -334,6 +334,11 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
         $this->config = is_array($config) ? $config : [];
     }
 
+    /**
+     * @param  array<string, mixed> $data
+     *
+     * @return void
+     */
     public function __unserialize(array $data): void
     {
         $this->config = $data;

--- a/src/Config.php
+++ b/src/Config.php
@@ -331,6 +331,12 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
         $this->config = is_array($config) ? $config : [];
     }
 
+    /**
+     * Sets the configuration from a stored representation.
+     *
+     * @param  mixed $data
+     * @return void
+     */
     public function __unserialize($data): void
     {
         $this->unserialize($data);

--- a/src/Config.php
+++ b/src/Config.php
@@ -314,6 +314,9 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
         return serialize($this->config);
     }
 
+    /*
+     * @return array<string, mixed>
+     */
     public function __serialize(): array
     {
         return $this->config;

--- a/src/Config.php
+++ b/src/Config.php
@@ -182,8 +182,9 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
     /**
      * Merges another config into this one.
      *
-     * @param  null|mixed[]|\Navindex\SimpleConfig\Config $config Configuration array or class
-     * @param  null|int                                   $method Merging method
+     * @param  null|mixed[]|Config $config Configuration array or class
+     * @param  null|int            $method Merging method
+     *
      * @return self
      */
     public function merge($config, ?int $method = null): self
@@ -238,11 +239,12 @@ class Config implements ArrayAccess, IteratorAggregate, Serializable, Countable
      * Splits a sub-array of configuration options into a new config.
      *
      * @param  string                        $key Dot notation key
-     * @return \Navindex\SimpleConfig\Config
+     *
+     * @return Config
      */
     public function split(string $key): self
     {
-        $value = $this->get($key);
+        $value = $this->get($key) ?? [];
         if (!is_array($value)) {
             $value = [$value];
         }


### PR DESCRIPTION
Per title, this will fix things up for PHP 8.1 to work.

Once this is merged in and a version is tagged, then https://github.com/navindex/html-formatter should also be updated and tagged with a release. That was the end goal here as I'm trying to use formatter with PHP 8.1

Of note, this change will drop support for EOL PHP 7.3 as well.